### PR TITLE
Prevent null names

### DIFF
--- a/lib/formatter.rb
+++ b/lib/formatter.rb
@@ -8,7 +8,7 @@ class Formatter
   def custom(account_id, region, service, resource)
     {
       account: account_id,
-      name: resource[:arn],
+      name: resource[:arn] || "#{account_id}_#{region}_#{service.name}_#{resource[:type]}",
       service: service.name,
       region: region,
       asset_type: resource[:type],


### PR DESCRIPTION
Internal tooling requires a unique name to be able to pick out the resource cleanly.  This custom formatter opportunistically uses the "arn" but builds one on the fly if it's null.