### PR TITLE
Handle S3 location_constraint == 'EU'

### DIFF
--- a/lib/aws_recon/collectors/s3.rb
+++ b/lib/aws_recon/collectors/s3.rb
@@ -37,6 +37,7 @@ class S3 < Mapper
                    struct.location = 'us-east-1'
                    @client
                  else
+                   location = 'eu-west-1' if location == 'EU'
                    struct.location = location
                    Aws::S3::Client.new({ region: location })
                  end


### PR DESCRIPTION
'EU' is a valid S3 location constraint, as an alias for eu-west-1.  It's not a valid API endpoint however.  This checks for 'EU' and sets location to 'eu-west-1' to avoid a NoSuchEndpoint error.