### PR TITLE
Honor `quit-on-exceptions` in all cases

### DIFF
--- a/lib/aws_recon/aws_recon.rb
+++ b/lib/aws_recon/aws_recon.rb
@@ -63,6 +63,10 @@ module AwsRecon
 
       # add resources to resources array for output to file
       @resources.concat(collection) if @options.output_file
+    rescue Aws::Errors::ServiceError => e
+      raise if @options.quit_on_exception
+
+      puts "Ignoring exception: '#{e.message}'\n"
     end
 
     #


### PR DESCRIPTION
When running the tool against an account missing `backup:ListProtectedResources` privileges, I noticed the program crashes instead of continuing as expected with the default of `quit_on_exceptions` set to `false`.

Turned out, the setting is only honored by some collectors. I added it as a catch-all to the central `collect`. Now it will continue on exceptions (default) or fail on errors (`--quit-on-exceptions` switch).