### PR TITLE
Add support for AWS Glue service

### DIFF
--- a/lib/aws_recon/collectors/glue.rb
+++ b/lib/aws_recon/collectors/glue.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#
+# Collect Glue resources
+#
+class Glue < Mapper
+    #
+    # Returns an array of resources.
+    #
+    def collect
+      resources = []
+      # 
+      # get_data_catalog_encryption_settings
+      #
+      @client.get_data_catalog_encryption_settings.each_with_index do | response, page|
+        log(response.context.operation_name, page)
+
+        struct = OpenStruct.new(response.to_h)
+        struct.type = 'catalog_encryption_settings'
+        struct.arn = "arn:aws:glue:#{@region}:#{@account}:data-catalog-encryption-settings" # no true ARN
+        resources.push(struct.to_h)
+      end
+
+      #
+      # get_security_configurations
+      #
+      @client.get_security_configurations.each_with_index do | response, page |
+        log(response.context.operation_name, page)
+
+        response.security_configurations.each do | security_configuration |
+            struct = OpenStruct.new(security_configuration.to_h)
+            struct.type = 'security_configuration'
+            struct.arn = "arn:aws:glue:#{@region}:#{@account}:security-configuration/#{security_configuration.name}" # no true ARN
+            resources.push(struct.to_h)
+        end
+      end
+
+      # 
+      # get_jobs
+      #
+      @client.get_jobs.each_with_index do | response, page |
+        log(response.context.operation_name, page)
+
+        response.jobs.each do | job |
+            struct = OpenStruct.new(job.to_h)
+            struct.type = 'job'
+            struct.arn = "arn:aws:glue:#{@region}:#{@account}:job/#{job.name}" 
+            resources.push(struct.to_h)
+        end
+      end
+
+      # 
+      # get_dev_endpoints
+      #
+      @client.get_dev_endpoints.each_with_index do | response, page |
+        log(response.context.operation_name, page)
+
+        response.dev_endpoints.each do | dev_endpoint |
+            struct = OpenStruct.new(dev_endpoint.to_h)
+            struct.type = 'dev_endpoint'
+            struct.arn = "arn:aws:glue:#{@region}:#{@account}:devEndpoint/#{dev_endpoint.endpoint_name}" 
+            resources.push(struct.to_h)
+        end
+      end
+
+      # 
+      # get_crawlers
+      #
+      @client.get_crawlers.each_with_index do | response, page |
+        log(response.context.operation_name, page)
+
+        response.crawlers.each do | crawler |
+            struct = OpenStruct.new(crawler.to_h)
+            struct.type = 'crawler'
+            struct.arn = "arn:aws:glue:#{@region}:#{@account}:crawler/#{crawler.name}"
+            resources.push(struct.to_h)
+        end
+      end
+
+      # 
+      # get_connections
+      #
+      @client.get_connections.each_with_index do | response, page |
+        log(response.context.operation_name, page)
+
+        response.connection_list.each do | connection |
+            struct = OpenStruct.new(connection.to_h)
+            struct.type = 'connection'
+            struct.arn = "arn:aws:glue:#{@region}:#{@account}:connection/#{connection.name}"
+            resources.push(struct.to_h)
+        end
+      end
+      resources
+    end
+
+end
+  

--- a/lib/aws_recon/services.yaml
+++ b/lib/aws_recon/services.yaml
@@ -41,6 +41,8 @@
   alias: elasticache
 - name: EMR
   alias: emr
+- name: Glue
+  alias: glue
 - name: IAM
   global: true
   alias: iam

--- a/lib/aws_recon/version.rb
+++ b/lib/aws_recon/version.rb
@@ -1,3 +1,3 @@
 module AwsRecon
-  VERSION = "0.5.26"
+  VERSION = "0.5.27"
 end

--- a/readme.md
+++ b/readme.md
@@ -368,6 +368,7 @@ AWS Recon aims to collect all resources and metadata that are relevant in determ
 - [x] Firehose
 - [ ] FMS
 - [ ] Glacier
+- [x] Glue
 - [x] IAM
 - [x] KMS
 - [x] Kafka


### PR DESCRIPTION
This PR adds support for collecting information from the [AWS Glue](https://aws.amazon.com/glue/) service.

This collects Glue security related information including:
- Data Catalog Encryption Settings (if in use, encryption type and whether passwords are encrypted)
- Glue Security Configurations (including s3, cloudwatch and job bookmark encryption)
- Jobs, including whether they utilise S3 encryption and applied security configuration.
- Dev endpoints, including the applied security configuration.
- Crawlers, including the applied security configuration.
- Connections, including whether a given connection enforces SSL.

I've provided a sample of the output [here](https://gist.github.com/PercussiveElbow/bbe36a8befdbfb080d165d2a2ab6a1b3#file-aws-recon-glue-sample-output)
