### PR TITLE
Enumerate public ECR repository information

### DIFF
--- a/lib/aws_recon/collectors/ecrpublic.rb
+++ b/lib/aws_recon/collectors/ecrpublic.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#
+# Collect ECRPublic resources
+#
+class ECRPublic < Mapper
+  #
+  # Returns an array of resources.
+  #
+  def collect
+    resources = []
+
+    #
+    # describe_repositories
+    #
+
+    puts(@client.describe_repositories)
+    @client.describe_repositories.each_with_index do |response, page|
+      log(response.context.operation_name, page)
+
+      response.repositories.each do |repo|
+        struct = OpenStruct.new(repo.to_h)
+        struct.type = "repository"
+        struct.arn = repo.repository_arn
+
+        struct.images = []
+        #
+        # describe images
+        #
+        puts(@client.describe_images({ repository_name: repo.repository_name }))
+        @client.describe_images({ repository_name: repo.repository_name }).image_details.each_with_index do |image, page|
+          log(response.context.operation_name, "list_images", page)
+          image_hash = image.to_h
+          struct.images << image_hash
+        end
+      rescue Aws::ECR::Errors::ServiceError => e
+        log_error(e.code)
+
+        raise e unless suppressed_errors.include?(e.code) && !@options.quit_on_exception
+      ensure
+        resources.push(struct.to_h)
+      end
+    end
+
+    resources
+  end
+
+  private
+
+  # not an error
+  def suppressed_errors
+    %w[
+      RepositoryPolicyNotFoundException,
+      ScanNotFoundException
+    ]
+  end
+end

--- a/lib/aws_recon/collectors/ecrpublic.rb
+++ b/lib/aws_recon/collectors/ecrpublic.rb
@@ -22,14 +22,15 @@ class ECRPublic < Mapper
         struct = OpenStruct.new(repo.to_h)
         struct.type = "repository"
         struct.arn = repo.repository_arn
+        struct.policy = @client
+          .get_repository_policy({ repository_name: repo.repository_name }).policy_text.parse_policy
 
         struct.images = []
         #
         # describe images
         #
-        puts(@client.describe_images({ repository_name: repo.repository_name }))
         @client.describe_images({ repository_name: repo.repository_name }).image_details.each_with_index do |image, page|
-          log(response.context.operation_name, "list_images", page)
+          log(response.context.operation_name, "describe_images", page)
           image_hash = image.to_h
           struct.images << image_hash
         end

--- a/lib/aws_recon/services.yaml
+++ b/lib/aws_recon/services.yaml
@@ -55,6 +55,33 @@
   alias: rds
 - name: ECR
   alias: ecr
+- name: ECRPublic
+  alias: ecrpublic
+  excluded_regions:
+    - af-south-1
+    - ap-east-1
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-northeast-3
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - ca-central-1
+    - eu-central-1
+    - eu-north-1
+    - eu-south-1
+    - eu-west-1
+    - eu-west-2
+    - eu-west-3
+    - me-south-1
+    - sa-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+    - af-south-1
+    - ap-east-1
+    - eu-south-1
+    - me-south-1
 - name: DynamoDB
   alias: dynamodb
 - name: KMS

--- a/lib/aws_recon/version.rb
+++ b/lib/aws_recon/version.rb
@@ -1,3 +1,3 @@
 module AwsRecon
-  VERSION = "0.5.29"
+  VERSION = "0.5.31"
 end

--- a/lib/aws_recon/version.rb
+++ b/lib/aws_recon/version.rb
@@ -1,3 +1,3 @@
 module AwsRecon
-  VERSION = "0.5.27"
+  VERSION = "0.5.29"
 end

--- a/readme.md
+++ b/readme.md
@@ -358,6 +358,7 @@ AWS Recon aims to collect all resources and metadata that are relevant in determ
 - [x] DynamoDB
 - [x] EC2
 - [x] ECR
+- [x] ECRPublic
 - [x] ECS
 - [x] EFS
 - [x] EKS


### PR DESCRIPTION
AWS Recon currently collects information on ECR repositories, however this does not include public ECR repositories, which fall under a slightly different service ([ECRPublic](https://docs.aws.amazon.com/AmazonECR/latest/public/what-is-ecr.html)) which appears to [only be available in us-east-1](https://docs.aws.amazon.com/general/latest/gr/ecr-public.html)

This PR collects the same information as the existing private ECR functionality, minus the image scan results which are not supported on public repositories.

A sample of this output is below:

```
{
    "account": "123456789",
    "service": "ECRPublic",
    "region": "us-east-1",
    "resource": {
      "repository_arn": "arn:aws:ecr-public::123456789:repository/reponame123",
      "registry_id": "123456789",
      "repository_name": "reponame123",
      "repository_uri": "public.ecr.aws/abc123/reponame123",
      "created_at": "2022-03-31 11:18:54 +0100",
      "type": "repository",
      "arn": "arn:aws:ecr-public::123456789:repository/reponame123",
      "policy": {
        "Version": "2008-10-17",
        "Statement": [
          {
            "Sid": "Example Statement",
            "Effect": "Allow",
            "Principal": {
              "AWS": "arn:aws:iam::123456789:user/username"
            },
            "NotAction": "ecr-public:DeleteRepositoryPolicy"
          }
        ]
      },
      "images": [
        {
          "registry_id": "123456789",
          "repository_name": "reponame123",
          "image_digest": "sha256:123456789",
          "image_tags": [
            "latest"
          ],
          "image_size_in_bytes": 545,
          "image_pushed_at": "2022-04-07 22:01:18 +0100",
          "image_manifest_media_type": "application/vnd.docker.distribution.manifest.v2+json"
        }
      ]
    },
    "timestamp": "2022-04-07 21:15:47 UTC"
  }
``` 