### PR TITLE
Add EFS Backup Policy support

### DIFF
--- a/lib/aws_recon/collectors/efs.rb
+++ b/lib/aws_recon/collectors/efs.rb
@@ -24,7 +24,6 @@ class EFS < Mapper
         #
         # Describe Backup Policy
         #
-        puts(filesystem.file_system_id)
         policy = @client.describe_backup_policy({file_system_id: filesystem.file_system_id})
         struct["backup_policy"] = policy.backup_policy.to_h
         rescue Aws::EFS::Errors::PolicyNotFound => e

--- a/lib/aws_recon/collectors/efs.rb
+++ b/lib/aws_recon/collectors/efs.rb
@@ -21,10 +21,28 @@ class EFS < Mapper
         struct.type = 'filesystem'
         struct.arn = filesystem.file_system_arn
 
-        resources.push(struct.to_h)
+        #
+        # Describe Backup Policy
+        #
+        puts(filesystem.file_system_id)
+        policy = @client.describe_backup_policy({file_system_id: filesystem.file_system_id})
+        struct["backup_policy"] = policy.backup_policy.to_h
+        rescue Aws::EFS::Errors::PolicyNotFound => e
+          # No backup policy configured for this filesystem. No action neded.
+        ensure
+          resources.push(struct.to_h)
       end
     end
 
     resources
   end
+
+  private 
+
+    # not an error
+    def suppressed_errors
+      %w[
+        Aws::EFS::Errors::PolicyNotFound
+        ]
+    end
 end

--- a/lib/aws_recon/version.rb
+++ b/lib/aws_recon/version.rb
@@ -1,3 +1,3 @@
 module AwsRecon
-  VERSION = "0.5.31"
+  VERSION = "0.5.32"
 end


### PR DESCRIPTION
This PR adds support for enumerating EFS filesystem [backup policies](https://docs.aws.amazon.com/efs/latest/ug/awsbackup.html) to determine whether or not backups have been enabled for a given filesystem.



